### PR TITLE
フォローリストでログインユーザーにフォローボタンが表示されていたのを解消

### DIFF
--- a/src/resources/views/users/list.blade.php
+++ b/src/resources/views/users/list.blade.php
@@ -8,12 +8,14 @@
         @foreach($list as $user)
             <li class="list-group-item">
                 <a href="{{ route('user.show', $user->login_id) }}">{{ $user->name }}</a>
-                <div>
-                    <follow-button
-                        :initial-is-followed-by='@json($user->isFollowedBy(Auth::user()))'
-                        endpoint="{{ route('user.follow', ['login_id' => $user->login_id]) }}"
-                    ></follow-button>
-                </div>
+                @if($user->login_id !== Auth::user()->login_id)
+                    <div>
+                        <follow-button
+                            :initial-is-followed-by='@json($user->isFollowedBy(Auth::user()))'
+                            endpoint="{{ route('user.follow', ['login_id' => $user->login_id]) }}"
+                        ></follow-button>
+                    </div>
+                @endif
             </li>
         @endforeach
         </ul>


### PR DESCRIPTION
別ユーザーのフォローリスト内でログインユーザーにフォローボタンが表示されていたので表示をなしにした。